### PR TITLE
FIX error An exception has been thrown during the rendering of a temp…

### DIFF
--- a/lib/Event/Subscriber/ComponentSidebarMenu.php
+++ b/lib/Event/Subscriber/ComponentSidebarMenu.php
@@ -77,21 +77,22 @@ class ComponentSidebarMenu implements EventSubscriberInterface
     protected function reorder(ItemInterface $parent): void
     {
         $children = $parent->getChildren();
-        $order = [];
-        foreach ($children as $templateName => $child) {
+        if (empty($children)) {
+            return;
+        }
+        foreach ($children as $child) {
             if ($child->hasChildren()) {
                 $this->reorder($child);
             }
-            $label = iconv('UTF-8', 'ASCII//TRANSLIT', $child->getLabel());
-            if (isset($order[$label])) {
-                $label = $templateName;
-                $child->setLabel($label);
-            }
-            $order[$label] = $child;
         }
-        ksort($order, SORT_LOCALE_STRING);
+        $childrenArray = array_values($children);
+        usort($childrenArray, static function (ItemInterface $a, ItemInterface $b): int {
+            $labelA = iconv('UTF-8', 'ASCII//TRANSLIT', $a->getLabel()) ?: $a->getName();
+            $labelB = iconv('UTF-8', 'ASCII//TRANSLIT', $b->getLabel()) ?: $b->getName();
+            return strcasecmp($labelA, $labelB);
+        });
         $parent->reorderChildren(
-            array_map(static fn (ItemInterface $item): string => $item->getName(), $order)
+            array_map(static fn (ItemInterface $item): string => $item->getName(), $childrenArray)
         );
     }
 }


### PR DESCRIPTION
FIX error An exception has been thrown during the rendering of a template ("Cannot reorder children, order does not contain all children.") in @StaticFakeDesign/showroom/layout/default.html.twig at line 25.


<img width="1250" height="488" alt="Capture d’écran 2026-05-25 à 19 12 49" src="https://github.com/user-attachments/assets/c308e229-55a9-49fb-adbd-2cc8d1e3b075" />

<img width="1137" height="748" alt="Capture d’écran 2026-05-25 à 19 13 21" src="https://github.com/user-attachments/assets/02d7dead-e5e5-4d9f-b126-02ef5b88e38b" />


Le problème est précisément lié à la façon dont ksort est utilisé ici.

  Avec ksort, le tri se fait sur les clés du tableau $order. Ces clés sont les labels après iconv (ex: "Cafe", "Bar"). Le bug se produit quand :

  1. Enfant A : name="Cafe", label="Café" → iconv → clé "Cafe" → $order["Cafe"] = enfantA
  2. Enfant B : name="Bar", label="Café" (même label) → iconv → clé "Cafe" → collision → fallback : $label = "Bar" → $order["Bar"] = enfantB ✓
  3. Enfant C : name="XYZ", label="Bar" → iconv → clé "Bar" → collision avec la clé de l'enfant B → fallback : $label = "XYZ" → $order["XYZ"] = enfantC ... mais enfant B 
  est perdu de $order

  Résultat : $order a 2 entrées, $children en a 3 → reorderChildren lance l'exception.

  Avec usort, on ne crée plus de clés du tout — on compare directement les labels des objets. Chaque enfant reste dans le tableau, le tri se fait sur les valeurs (les
  labels translitérés), et on passe les noms exacts à reorderChildren. Impossible de perdre un enfant.
